### PR TITLE
Fixed extra digit time range issue, isProbablyWind issue

### DIFF
--- a/taf_checker.html
+++ b/taf_checker.html
@@ -60,10 +60,14 @@ TEMPO 0102/0108 4000 BLDU TXM05/0113Z TNM06/0114Z
                     if (isProbablyBecmg(line)) {
                         tafErrors = tafErrors.concat(validateBecmg(line, lineNo, tafLines.length, tafStart, tafEnd, lastLineStart, lastLineWx));
                         lastPredomLine = lineNo;
-                        lastLineStart = getLineValidTime(line);
+                        if (lineHasValidTimeRange(line, tafStart, tafEnd, lastLineStart, false)) {
+                            lastLineStart = getLineValidTime(line);
+                        }
                     } else if (isProbablyTempo(line)) {
                         tafErrors = tafErrors.concat(validateTempo(line, lineNo, tafLines.length, tafStart, tafEnd, lastLineStart, lastLineWx));
-                        lastLineStart = getLineValidTime(line);
+                        if (lineHasValidTimeRange(line, tafStart, tafEnd, lastLineStart, true)) {
+                            lastLineStart = getLineValidTime(line);
+                        }
                     } else {
                         tafErrors.push("LINE " + lineNo + ": Line type not understood");
                     }
@@ -875,7 +879,7 @@ TEMPO 0102/0108 4000 BLDU TXM05/0113Z TNM06/0114Z
             }
            
             function isProbablyWind(wind) {
-                return (wind.endsWith("KT") || wind.startsWith("VRB") || isNumeric(wind.substring(0,5)));
+                return (wind.endsWith("KT") && (wind.startsWith("VRB") || isNumeric(wind.substring(0,5))));
             }
            
  	    function isValidWind(wind) {
@@ -1164,12 +1168,18 @@ TEMPO 0102/0108 4000 BLDU TXM05/0113Z TNM06/0114Z
                 return (firstLine.split(" ")[1] == "COR");
             }
 
+            function lineHasValidTimeRange(line, tafStart, tafEnd, lastLineStart, isTempo) {
+                fields = line.split(" ");
+                return isValidLineTimeRange(fields[1], tafStart, tafEnd, lastLineStart, isTempo);
+            }
+
             function isValidLineTimeRange(field, tafStart, tafEnd, lastLineStart, isTempo) {
                 var lineStart = getStartTimeFromField(field);
                 var lineStartHour = parseInt(lineStart.substring(2,4));
                 var lineEnd = getEndTimeFromField(field);
                 var lineEndHour = parseInt(lineEnd.substring(2,4));
-                if (!isProbablyTimeRange(field)) { return false; }
+                if (field.length != 9 || field.substring(4,5) != "/") { return false; }
+                else if (!isProbablyTimeRange(field)) { return false; }
                 else if (!isValidDayHour(lineStart) || !isValidDayHour(lineEnd)) { return false; }
                 else if (lineEndHour <= 0 || lineStartHour > 24) { return false; }
                 else if (!isDDHHLessThan(lineStart, lineEnd)) {  return false; }


### PR DESCRIPTION
Hey Desmond, 

There are two issues in this pull request.

The first is the one you sent a screenshot about.  We were running into a situation where we were setting "lastLineStart" time in the main validateTAF() function after each line, even if that line had an invalid time window.  So I added a function to check if the line has a valid time window, and don't set lastLineStart if that is the case (it will default to the last known good lastLineStart, or the tafStart, if necessary).

The second one is one I just stumbled onto where I had a tempo like "TEMPO 0101/0102 1000 DU", and 1000 was coming up as true for isProbablyWind, and it was telling me that line had bad winds.  I adjusted the logic in isProbablyWind to fix this problem.

Can you:
- Check to see if the isProbablyWind logic makes sense to you?
- Test out the changes to make sure they fixed the problem, but also didn't introduce any new problems?

Let me know if you have any questions